### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "moment": "^2.24.0",
     "ng-pick-datetime": "^7.0.0",
     "ngx-bootstrap": "^4.0.1",
-    "npm": "^6.9.0",
     "open-iconic": "^1.1.1",
     "primeng": "6.0.0",
     "rxjs": "~6.3.3",


### PR DESCRIPTION

Hello andreimatei818!

It seems like you have npm as one of your (dev-) dependency in frontLicenta.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
